### PR TITLE
fix(ci): set workflow permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,6 +75,8 @@ jobs:
     needs:
       - build
       - test
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Check Jobs Succeeded


### PR DESCRIPTION
Potential fix for [https://github.com/SlickyCorp-Heavy-Manufacturing/SlickBot/security/code-scanning/2](https://github.com/SlickyCorp-Heavy-Manufacturing/SlickBot/security/code-scanning/2)

Add an explicit `permissions` block to the `ci` job in `.github/workflows/ci.yaml` so the job does not inherit potentially broad defaults.  
Best minimal fix without changing behavior: set `contents: read` for `ci`, since it only reads workflow/job state and does not perform PR/comment/package writes.

Change location:
- File: `.github/workflows/ci.yaml`
- Region: `jobs.ci` block (around lines 72–79)
- Add:
  - `permissions:`
  - `contents: read`

No imports, methods, or dependencies are required (YAML workflow edit only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
