### PR TITLE
fix(ci): set workflow permisison

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     name: Docker Build
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/SlickyCorp-Heavy-Manufacturing/SlickBot/security/code-scanning/1](https://github.com/SlickyCorp-Heavy-Manufacturing/SlickBot/security/code-scanning/1)

Add an explicit `permissions` block to the `build` job in `.github/workflows/ci.yaml`, matching least privilege required for this job.

Best fix without changing functionality:
- In the `build` job (around lines 10–12), add:
  - `permissions:`
  - `contents: read`

This preserves current behavior (checkout and build) while constraining token privileges. No imports, methods, or external definitions are needed in YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
